### PR TITLE
login 時のpassword-confirmationを削除

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -22,7 +22,7 @@ class ReviewsController < ApplicationController
     if session[:lat] && session[:lng]
       @center = { "lat" => session[:lat], "lng" => session[:lng]}
     else
-      @center = { "lat" => 34.6937249, "lng" => 135.5022535 }
+      @center = { "lat" => 10.3154, "lng" => 123.886 }
     end
     respond_to do |format|
       format.html

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,12 +9,14 @@ class SessionsController < ApplicationController
       user = User.find_or_create_from_auth(auth)
       log_in (user)
       current_user
+      flash[:success]="Login しました。"
       redirect_to root_url
     else
       @user = User.find_by(email: params[:session][:email].downcase)
       if @user && !!@user.authenticate(params[:session][:password])
         log_in (@user)
         current_user
+        flash[:success]="Login しました。"
         redirect_to root_url
       else
         flash.now[:danger] = "メールアドレスかパスワードが正しくありません"

--- a/app/javascript/components/Signup.js
+++ b/app/javascript/components/Signup.js
@@ -106,8 +106,6 @@ class Signup extends React.Component {
             <input className="form_input" type="text" name="session[email]" id="user_email" value={this.state.user_email} onChange={this.handleChange} />
             <label htmlFor="user_password">パスワード</label>
             <input className="form_input" type="password" name="session[password]" id="user_password" value={this.state.user_password} onChange={this.handleChange} />
-            <label htmlFor="user_password_confirmation">パスワード確認用</label>
-            <input className="form_input" type="password" name="session[password_confirmation]" id="user_password_confirmation" value={this.state.user_password_confirmation} onChange={this.handleChange} />
 
             <input className="form_submit" type="submit" name="submit" value="Loginする" />
             <button className="login" onClick={this.signupcontroll}>

--- a/app/views/roots/root.html.erb
+++ b/app/views/roots/root.html.erb
@@ -9,7 +9,8 @@
       <h3 class="window_description">気になる国や街の住み心地を<br>チェック！</h3>
       <h3 class="window_description">留学や移住の前に<br>レビューを見てみよう！</h3>
       <% if logged_in? %>
-        <h3>Welcome!<br><%= @current_user.name %></h3>
+        <h2 style="margin-bottom: 10px;">Welcome!</h2>
+        <h2> <%= @current_user.name %></h2>
         <!--<%= link_to "Log out", logout_path , method: :post %> -->
       <% else %>
         <div class="window_signup">


### PR DESCRIPTION
close #96 
login時にpasswordを確認する必要がないので、login-formではpassword_confirmationを表示させなくして、postでもemailとpasswordしか送信しない。